### PR TITLE
fix: set default values for darkmode

### DIFF
--- a/packages/core/src/state/user/hooks.ts
+++ b/packages/core/src/state/user/hooks.ts
@@ -51,7 +51,7 @@ import {
 } from "./actions";
 
 export function useIsDarkMode(): boolean {
-  const { userDarkMode, matchesDarkMode } = useAppSelector(
+  const { userDarkMode = true, matchesDarkMode = true } = useAppSelector(
     ({ user: { matchesDarkMode, userDarkMode } }) => ({
       userDarkMode,
       matchesDarkMode,


### PR DESCRIPTION
On first load the userDarkmode can be undefined.
The default will be used in that case.